### PR TITLE
Another suggestion: simplify the iterator in `either`

### DIFF
--- a/source/com/athaydes/parcey/combinator/combinators.ceylon
+++ b/source/com/athaydes/parcey/combinator/combinators.ceylon
@@ -89,8 +89,8 @@ shared Parser<Item> either<Item>({Parser<Item>+} parsers, String name_ = "") {
             value result = {
                 for (p in parsers)
                 if (!is ErrorMessage outcome = p.doParse(consumer))
-                then outcome else null
-            }.filter((item) => item exists).first;
+                outcome
+            }.first;
             if (exists result) {
                 consumer.clearError();
                 return result;


### PR DESCRIPTION
It should work the same, but in my case this even improves situation (one bug with stack overflow on circularly-dependent parsers vanishes, althrough a strange other bug is left, but I can’t yet reproduce it in a minimal example).
